### PR TITLE
Fixed non-use of hint

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -371,7 +371,7 @@ $M_1(z)$ but with $\lambda+\mu$ replacing $\lambda$, we can conclude that $N(t)\
     holds for any time $h$, whether it is small or not.  \hint{Suppose
       we write $N(t)=N_a(t) + N_s(t)$. Then
       \begin{equation*}
-      \P{N_a(h) = 1, N_s(h) = 0 | N(t) = 1}
+      \P{N_a(h) = 1, N_s(h) = 0 | N(h) = 1}
       \end{equation*}
       is the probability that $N_a(h)=1$ and $N_s(h)=0$ \emph{given}
       that $N(t)=1$. In other words, the question is find out that,

--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -371,7 +371,7 @@ $M_1(z)$ but with $\lambda+\mu$ replacing $\lambda$, we can conclude that $N(t)\
     holds for any time $h$, whether it is small or not.  \hint{Suppose
       we write $N(t)=N_a(t) + N_s(t)$. Then
       \begin{equation*}
-      \P{N_a(h) = 1, N_s(h) = 0 | N_a(h) + N_s(h) = 1}
+      \P{N_a(h) = 1, N_s(h) = 0 | N(t) = 1}
       \end{equation*}
       is the probability that $N_a(h)=1$ and $N_s(h)=0$ \emph{given}
       that $N(t)=1$. In other words, the question is find out that,


### PR DESCRIPTION
'Write xx as xx' wordt niet gebruikt. Denk copy-paste foutje.