### PR TITLE
Typo in Exercise 1.1.8

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -227,10 +227,10 @@ As  will become clear later, the SCV is a very important concept in
   variability}.
 
 \begin{exercise}
-Show that   the SCV of $N(t)$ is equal to $1/(\lambda t)^2$. 
+Show that   the SCV of $N(t)$ is equal to $1/\lambda t$. 
   \begin{solution}
     \begin{equation*}
-SCV = \frac{\V{N(t)}}{(\E{N(t)})^2} = \frac{\lambda t}{(\lambda t)^2} = \frac1{(\lambda t)^2}.
+SCV = \frac{\V{N(t)}}{(\E{N(t)})^2} = \frac{\lambda t}{(\lambda t)^2} = \frac1{\lambda t}.
     \end{equation*}
 
   \end{solution}


### PR DESCRIPTION
Solution and exercise description had a square power which should not be there.
Solution should be \frac{1}{\lambda t}