### PR TITLE
Fixed one typo / grammar error

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -27,7 +27,7 @@ The constant $\lambda$ is often called the \recall{arrival rate}.
 
 The second assumption is that the process $\{N(s,t], s\leq t\}$ has
 \recall{stationary} and \emph{independent increments}. Stationarity
-means that the distribution of the number of arrivals are the same for
+means that the distributions of the number of arrivals are the same for
 all intervals of equal length. Formally, $N(s_1,t_1]$ has the same
 distribution as $N(s_2, t_2]$ if $t_2-s_2 = t_1-s_1$. Independence
 means, roughly speaking, that knowing that $N(s_1,t_1]= n$, does not


### PR DESCRIPTION
Made 'distribution' plural to match the 'are the same' in "Stationarity means that the distribution of the number of arrivals are the same for all intervals of equal length."