### PR TITLE
missing ":" sign

### DIFF
--- a/tex_files/usefulidentities.tex
+++ b/tex_files/usefulidentities.tex
@@ -965,7 +965,7 @@ Ls
 \end{pyconsole}
 
 
-The average number in queue 
+The average number in queue: 
 \begin{pyconsole}
 c = 2
 Lq = sum((n-c)*P[n] for n in range(c,len(P)))


### PR DESCRIPTION
It would be more neat if you add a ":" sign at the end of this sentence.