### PR TITLE
Dot missing

### DIFF
--- a/tex_files/mxm1_pk.tex
+++ b/tex_files/mxm1_pk.tex
@@ -178,7 +178,7 @@ Use Eq.~\ref{eq:43}. What are $\E{B^2}$, $\E B$ and $\V B$ for this case?
 \begin{exercise}
   If the batch size is $p$ geometrically distributed, what is $\E L$?
   \begin{hint}
-$f_k=q^{k-1}p$ with $q=1-p$. Use generating functions to compute $\E B$ and $\E{B^2}$
+$f_k=q^{k-1}p$ with $q=1-p$. Use generating functions to compute $\E B$ and $\E{B^2}$.
   \end{hint}
 \begin{solution}
   We need $\V B$ and $\E B$. Consider


### PR DESCRIPTION
A dot is missing behind this sentence (the hint of exercise 1.15.6).