### PR TITLE
Update open_single_class.tex

### DIFF
--- a/tex_files/open_single_class.tex
+++ b/tex_files/open_single_class.tex
@@ -303,7 +303,7 @@ P^2 = V^{-1}\Lambda V \cdot V^{-1}\Lambda V= V^{-1}\Lambda^2 V,
 \end{equation*}
 and in general $P^n = V^{-1}\Lambda^n V$. If each eigenvalue
 $\lambda_i$ is such that its modulus $|\lambda_i| < 1$, then
-$\Lambda^n \to 0$ geometrically fast, hence $P^n\to n$ geometrically
+$\Lambda^n \to 0$ geometrically fast, hence $P^n\to 0$ geometrically
 fast, hence the sequence of partial sums $\sum_{n=0}^N P^n$ must
 converge to some finite number as $N\to\infty$. 
 
@@ -318,7 +318,7 @@ center at the diagonal elements $a_{ii}$ of $A$ and radius equal
 to the sum of the (modulus of the) elements of $A$ on the $i$th row
 except $a_{ii}$. Then Gerschgorin's theorem says that all eigenvalues
 of $A$ lie in the union of these disks, i.e., all eigenvalues
-$\lambda_i \in \bigcup_i B_{a_{ii}, \sum_{j\neq i}|a_{i j}})$.
+$\lambda_i \in \bigcup_i B({a_{ii}, \sum_{j\neq i}|a_{i j}})$.
 
 Assume for notational simplicity that for each row $i$ of $P$ we have
 that $\sum_{j} a_{i j}<1$. (Otherwise apply the argument to $P^{M+1}$.)


### PR DESCRIPTION
typo's: P^n converges to zero (not to n), missing opening bracket