### PR TITLE
Update poissondistribution.tex

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -283,7 +283,7 @@ For the next couple of exercises, we need the concept of conditional probability
 
 Below, and elsewhere, we use the following efficient notation:  the function $f=o(h)$ means that $f$ is such $f(h)/h \to 0$ as $h\to 0$.  The next exercise helps you practice with this notation.
 \begin{exercise}
-  Let $c$ be a constant (in $\R$) and the functions $f$ and $g$ both of $o(h)$. Then $f(h) \to 0$ when $h\to 0$, $c\cdot f = o(h)$, $f+g=o(h)$, and $f\cdot g=o(h)$. 
+  Let $c$ be a constant (in $\R$) and the functions $f$ and $g$ both of $o(h)$. Then show that $f(h) \to 0$ when $h\to 0$, $c\cdot f = o(h)$, $f+g=o(h)$, and $f\cdot g=o(h)$. 
  \begin{solution}
 First,
 \begin{align*}


### PR DESCRIPTION
The indication of exercise 1.1.10 being an actual exercise was missing. Added 'show that' since this is the general language used in the book when a proof is required. Possibly the exercise would be even clearer if (1), (2), (3), (4) was added before each part of the exercise and correspondingly this numbering was added to the solutions. The solutions could be clearer if the proof of (1) was then added to the solutions, however, this proof is clearly trivial and hence this could be deemed unnecessary.