### PR TITLE
Update expdistribution.tex

### DIFF
--- a/tex_files/expdistribution.tex
+++ b/tex_files/expdistribution.tex
@@ -829,7 +829,7 @@ $\E S = \int_0^\infty x \d F  = \int_0^\infty \int_0^\infty 1_{y\leq x} \d y \d 
 \begin{equation*}
   \begin{split}
     \E{S} &= \int_0^\infty x \d F  = \int_0^\infty \int_0^x \d y \d F(x) \\
-    & = \int_0^\infty \int_0^\infty 1_{y\leq x} \d y \d F(x)   = \int_0^\infty \int_0^\infty 1_{y\leq x} \d F(x) \d y\\
+    & = \int_0^\infty \int_0^\infty 1\{y\leq x} \d y \d F(x)   = \int_0^\infty \int_0^\infty 1\{y\leq x} \d F(x) \d y\\
     & = \int_0^\infty \int_y^\infty \d F(x) \d y = \int_0^\infty G(y) \d y.
   \end{split}
 \end{equation*}


### PR DESCRIPTION
I don't know if is really a mistake, but usually a different notation for the indicator function is used.