### PR TITLE
Update poissondistribution.tex

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -301,9 +301,9 @@ For (4), use  the Algebraic Limit Theorem,
 
 
 \begin{exercise}
-  Show that if $N(t) \sim P(\lambda t)$, we have for small $h$,
+  Show that if $N(t) \sim P(\lambda t)$, we have for small $h$ such that $|\lambda h| \ll 1$,
   \begin{equation*}
-\P{N(t+h) = n \given N(t) = n} = 1-\lambda h + o(h).
+\P{N(t+h) = n \given N(t) = n} = 1-\lambda h + o(\lambda h).
   \end{equation*}
     \begin{hint}
 Use  the definition of the conditional probability of Exercise~\ref{ex:18}. 
@@ -322,9 +322,9 @@ Use  the definition of the conditional probability of Exercise~\ref{ex:18}.
 Write $N(s, t]$ for the number of arrivals in the interval $(s,t]$. First we make a few simple observations: $N(t+h]= N(t) + N(t, t+h]$, hence
 \begin{equation*}
   \begin{split}
-  \1{N(t+h)=n, N(t)=n}
-&=  \1{N(t) + N(t, t+h] = n, N(t)=n} = \\
-&\1{N(t, t+h] = 0, N(t)=n}.
+  \P{N(t+h)=n, N(t)=n}
+&=  \P{N(t) + N(t, t+h] = n, N(t)=n} = \\
+&\P{N(t, t+h] = 0, N(t)=n}.
   \end{split}
 \end{equation*}
 Thus, 


### PR DESCRIPTION
Concerning exercise 1.1.11 and its solution. 

When in the solutions we find P(N(0, h] = 0) = Poisson(lambda×h),  we are working with a Poisson distribution with parameter lambda×h and k=0. We end up with an exp{-lambda×h}. Clearly then, by Taylor expansion for abs(lambda×h) << 1, this converges to 1 - lambda×h + o(lambda×h)  (if I understand the o(h) notation correctly). If only abs(h) << 1, then for large lambda, we might still have that abs(lambda×h) is not << 1. In this case, we cannot apply the Taylor expansion in the way that it is applied in the solutions. Thus I added the line 'such that $|\lambda×h| \ll 1$' and changed 'o(h)' to 'o(lambda×h)', as we are working with a function of lambda h and not a function of just h. Furthermore, I changed the odd looking 1 in the solutions to the probability P letter since I think that's what it was supposed to be. I might just have missunderstood the solution to the exercise though! Please take a good look.