### PR TITLE
Update poissondistribution.tex

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -186,7 +186,7 @@ Show that the moment generating function of the random variable~$N(t)\sim P(\lam
 \begin{equation*}
 M_{N(t)}(s) 
 %=  \E{e^{sN(t)}}  
-= \exp{\lambda t(e^s-1)}.
+= \exp{(\lambda t(e^s-1))}.
 \end{equation*}
   \begin{hint}Observe first that for a random variable $X\in\N$ and some function $f$, we have that
     \begin{equation*}


### PR DESCRIPTION
Brackets not shown for exp( ... ) in exercise 1.1.6