### PR TITLE
S1.1.15 \mu depends on s instead of t

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -508,7 +508,7 @@ With this,
 Now with the moment generating functions of $N_\lambda(t)$ and $N_\mu(t)$, and using that by the independence of  $N_\lambda(t)$ and $N_\mu(t)$, the moment generating function of $N_\lambda + N_\mu$ is the product of the moment generating functions of $N_\lambda$ and $N_\mu$, 
 \begin{align*}
 M_{N_\lambda(t)+N_\mu(t)}(s) 
-&= M_{N_\lambda(t)}(s) M_{N_\mu(s)} \\
+&= M_{N_\lambda(t)}(s) M_{N_{\mu(t)}(s) \\
 &=\exp(\lambda t (e^s -1)) \exp(\mu t(e^s-1)) \\
 &= \exp((\lambda + \mu)t (e^s-1)).
 \end{align*}


### PR DESCRIPTION
The moment generating of the sum of the Poisson distributions is the product of the moment generating functions. In the first line of  the equation that illustrates this statement , \mu depends on s, instead of t.