### PR TITLE
Update poissondistribution.tex

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -390,7 +390,7 @@ process is an uncountable set of random variables indexed by  $t\in \R^+$, where
 \begin{exercise}
 Show that  for a Poisson process $N$, 
 \begin{equation*}
-\P{N(s] =1\given N(t]=1} = \frac s t,
+\P{N(s) =1\given N(t)=1} = \frac s t,
 \end{equation*}
 if $s\in[0,t]$. Thus, if you know that an arrival occurred during $[0,t]$, the arrival is distributed
 uniformly on the interval $[0,t]$.


### PR DESCRIPTION
Changed brackets in exercise 1.1.14 from N(s] and N(t] to N(s) and N(t); alternatively N(0,s] and N(0,t] could also be used (as in de solutions)