### PR TITLE
Update poissondistribution.tex

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -636,7 +636,7 @@ Method 1: Suppose that  $N_1$ is the  thinned stream, and $N$ the total stream. 
 = e^{-\lambda} \frac{(\lambda p)^k}{k!} e^{\lambda(1-p)} \\
 &= e^{-\lambda p} \frac{(\lambda p)^k}{k!}.
 \end{align*}
-We see that the thinned stream is Poisson with parameter $\lambda p$. (For notational ease, we left out the $t$, otherwise it is $P(\lambda t p)$. 
+We see that the thinned stream is Poisson with parameter $\lambda p$. (For notational ease, we left out the $t$, otherwise it is $P(\lambda t p)$.) 
 
 Method 2: Now consider $Y=\sum_{i=1}^N Z_i$. Suppose that $N=n$, so that $n$
 arrivals occurred. Then we throw $n$ coins with success probability


### PR DESCRIPTION
Concering that missing ). Not sure where I went wrong in that you couldn't find it. I've made the same pull request this time, but I'll add what I changed here:

In line 639 we originally have:
We see that the thinned stream is Poisson with parameter $\lambda p$. (For notational ease, we left out the $t$, otherwise it is $P(\lambda t p)$.

We should have:
We see that the thinned stream is Poisson with parameter $\lambda p$. (For notational ease, we left out the $t$, otherwise it is $P(\lambda t p)$.)

I hope you can find it now, sorry for the inconvenience.