### PR TITLE
Update Constructiondiscretetime.tex

### DIFF
--- a/tex_files/constructiondiscretetime.tex
+++ b/tex_files/constructiondiscretetime.tex
@@ -196,7 +196,7 @@ Q.std()
 
 
 I multiply with 100 to get a percentage. Clearly, many jobs see a long
-queue, the mean is already some 24 jobs. For this arrival rate a
+queue, the mean is already some 28 jobs. For this arrival rate a
 service capacity of $\mu=21$ is certainly too small. 
 
 


### PR DESCRIPTION
According to the output of the python code, Q.mean() = 28.42. However, in the text in line 199 the mean of the number of jobs  is given by 'some 24 jobs', which should be 'some 28 jobs' if I'm correct.