### PR TITLE
changing word

### DIFF
--- a/tex_files/mda.tex
+++ b/tex_files/mda.tex
@@ -320,7 +320,7 @@ improving the bottleneck.
   Consider Example 3.5. Suppose you would add an extra machine to
   station 0. What will become the throughput and the average number of
   jobs at each station? Use the Marginal Distribution Analysis
-  Algorithm. Plot also the distribution of the number of jobs in
+  Algorithm. Plot also the distribution of the number of jobs at
   stations 0 and 1.
   \begin{solution}
     I first implement the algorithm. Then I use the case, i.e., the


### PR DESCRIPTION
Changed 'in stations 0 and 1' into 'at stations 0 and 1', since its asked what the throughput and the average number of jobs become at each station, instead of 'in'.