### PR TITLE
style

### DIFF
--- a/tex_files/kendall.tex
+++ b/tex_files/kendall.tex
@@ -143,7 +143,7 @@ $M/G/1$: the inter-arrival times are exponentially distributed,
 \begin{exercise}
   What is the meaning of $M/D/1-LIFO$?
   \begin{solution}
- $M/D/1-LIFO$.  Now job service times are Deterministic, and the service sequence is last-in-first-out (LIFO).
+ $M/D/1-LIFO$.  Now job-service times are deterministic, and the service sequence is last-in-first-out (LIFO).
   \end{solution}
 \end{exercise}
 

--- a/tex_files/kendall.tex
+++ b/tex_files/kendall.tex
@@ -116,7 +116,7 @@ $M(n)/M(n)/1$: the inter-arrival times are exponential, just as
   What is the meaning of $M/G/1$?
   \begin{solution}
 $M/G/1$: the inter-arrival times are exponentially distributed,
-  the service times can have any General distribution (with
+  the service times can have any general distribution (with
   finite mean), and there is 1 server.
   \end{solution}
 \end{exercise}
@@ -143,7 +143,7 @@ $M/G/1$: the inter-arrival times are exponentially distributed,
 \begin{exercise}
   What is the meaning of $M/D/1-LIFO$?
   \begin{solution}
- $M/D/1-LIFO$.  Now job-service times are deterministic, and the service sequence is last-in-first-out (LIFO).
+ $M/D/1-LIFO$.  Now job service times are deterministic, and the service sequence is last-in-first-out (LIFO).
   \end{solution}
 \end{exercise}
 


### PR DESCRIPTION
Changed 'job service times' into 'job-service times' (as we also see inter-arrival times instead of 'inter arrival times').  Also changed 'Deterministic' into 'deterministic' because of unnecessary use of a capital letter.