### PR TITLE
typo

### DIFF
--- a/tex_files/failures.tex
+++ b/tex_files/failures.tex
@@ -463,7 +463,7 @@ Zijm.Ex.1.11.7
   with average $\mu_i^{-1}$ for family $i$. A setup of time $S$ is
   required if the machine switches from one family to another. If the
   machine works according to a cyclic schedule, i.e., produce family
-  1, then 2, then 3, and so on until family $n$, Can you find batch
+  1, then 2, then 3, and so on until family $n$, can you find batch
   sizes $B_i$ for family $i$ such that an average waiting time can be
   guaranteed?
   \begin{solution}


### PR DESCRIPTION
Changed a capital letter -after a comma in a question- into a small letter.