### PR TITLE
Update constructioncontinuoustime.tex

### DIFF
--- a/tex_files/constructioncontinuoustime.tex
+++ b/tex_files/constructioncontinuoustime.tex
@@ -585,7 +585,7 @@ obtained a set of recursions by which we can run a simulation of a
 queueing process of whatever length we need, provided we have a
 sequence of inter-arrival times $\{X_k\}$ and service times
 $\{S_k\}$.  A bit of experimentation with computer programs such as
-$R$ or python will reveal that this is easy.
+$R$ or Python will reveal that this is easy.
 
 
 


### PR DESCRIPTION
Python should have a capital according to its site.