### PR TITLE
Update intro.tex

### DIFF
--- a/tex_files/intro.tex
+++ b/tex_files/intro.tex
@@ -210,7 +210,7 @@ J.W.
 Nieuwenhuis for our many discussions on the formal aspects of queueing theory, prof.
 dr.
 W.H.M.
-Zijm for allowing me to use the first few chapters of his book, and my students for finding and correcting errors and typo's, and improving explanations.
+Zijm for allowing me to use the first few chapters of his book, and my students for finding and correcting errors and typos, and improving explanations.
 
 %\clearpage
 


### PR DESCRIPTION
The plural of typo is typos, not typo's. See https://en.wiktionary.org/wiki/typo#Noun