### PR TITLE
Update open_single_class.tex

### DIFF
--- a/tex_files/open_single_class.tex
+++ b/tex_files/open_single_class.tex
@@ -445,7 +445,7 @@ are $3$ taxi cabs. When a group arrives (at rate $\lambda$), there is
 one taxi less, and so on, until there are no more taxis
 left. Finally, if yet more groups arrive, they have to wait. When a
 new taxi arrives, the number of groups is reduced by one, and so on,
-until there are $3$ taxi's waiting and no groups of people.
+until there are $3$ taxis waiting and no groups of people.
 
 
     \begin{center}


### PR DESCRIPTION
The plural of taxi is taxis or taxies, not taxi's. See https://en.wiktionary.org/wiki/taxi#Noun