### PR TITLE
Update constructioncontinuoustime.tex

### DIFF
--- a/tex_files/constructioncontinuoustime.tex
+++ b/tex_files/constructioncontinuoustime.tex
@@ -278,7 +278,7 @@ Dropping the dependence on $k$ for ease, we get
 \end{align*}
 With this
   \begin{align*}
-    \P{W_{Q,1} = 1} &=\P{W_{Q,0} + Y_0= 1} = \P{3 + Y_0 =1} = \P{Y_0=-2} =\frac14,\\
+    \P{W_{Q,1} = 1} &=\P{W_{Q,0} + Y_1= 1} = \P{3 + Y_1 =1} = \P{Y_1=-2} =\frac14,\\
     \P{W_{Q,1} = 2} &= \P{3 + Y =2} = \P{Y=-1}  =\frac14,\\
     \P{W_{Q,1} = 3} &= \P{3 + Y = 3} = \P{Y=0}  =\frac14,\\
     \P{W_{Q,1} = 4} &= \P{3 + Y = 4} = \P{Y=1}  =\frac14.\\


### PR DESCRIPTION
Y_k is defined as Y_k = S_{k-1} - X_k and W_{Q,k} = W_{Q, k-1} + Y_k. Therefore when we want to calculate W_{Q,1}, K = 1 so Y_k = Y_1 and not Y_0. If we use Y_0 then S_{k-1} = S_{-1}.