### PR TITLE
Update poissondistribution.tex

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -238,7 +238,7 @@ As  will become clear later, the SCV is a very important concept in
   variability}.
 
 \begin{exercise}
-Show that   the SCV of $N(t)$ is equal to $1/\lambda t$. 
+Show that   the SCV of $N(t)$ is equal to $1/(\lambda t)$. 
   \begin{solution}
     \begin{equation*}
 SCV = \frac{\V{N(t)}}{(\E{N(t)})^2} = \frac{\lambda t}{(\lambda t)^2} = \frac1{\lambda t}.


### PR DESCRIPTION
lambda*t should be in brackets. The way it is now implies that the SCV of N(t) is t/lambda, which is not true