### PR TITLE
Update kendall.tex

### DIFF
--- a/tex_files/kendall.tex
+++ b/tex_files/kendall.tex
@@ -34,7 +34,7 @@ Two inter-arrival and service
 distributions  are the most important in queueing theory: the
 exponential distribution denoted with the shorthand $M$, as it is
 memoryless, and a general distribution (with the implicit assumption
-that it's first moment is finite) denoted with $G$.
+that its first moment is finite) denoted with $G$.
 
 Familiarize yourself with this notation as it is used continuously in the rest of the book. Here are some exercises to illustrate the notation.
 


### PR DESCRIPTION
Typo; it's should be replaced by its. See: https://en.oxforddictionaries.com/usage/its-or-it-s