### PR TITLE
Typo in subscript

### DIFF
--- a/tex_files/constructiondiscretetime.tex
+++ b/tex_files/constructiondiscretetime.tex
@@ -819,7 +819,7 @@ d_{k}^A$. Thus,
 \end{equation}
 This is a bit subtle: since there is room $M-Q^B_{k-1}$ at the
 intermediate buffer and $d_k^A \leq M-Q^B_{k-1}$, we know that in the
-worst case, i.e., when $c_k^B=0$, still $Q^B_k = Q_{k_1}^B +
+worst case, i.e., when $c_k^B=0$, still $Q^B_k = Q_{k-1}^B +
 d_k^A$.
 Thus, we are sure that the queue length of the intermediate queue will
 not exceed $M$.


### PR DESCRIPTION
k-1 instead of k_1