### PR TITLE
Update constructioncontinuoustime.tex

### DIFF
--- a/tex_files/constructioncontinuoustime.tex
+++ b/tex_files/constructioncontinuoustime.tex
@@ -449,8 +449,8 @@ Why don't we need separate notation for $D_s(t)$, the number
 
 \begin{exercise}
  Consider a multi-server queue with $m$ servers. Suppose that
-    at some time~$t$ it happens that $\tilde A(t) - D_s(t) < m$ even though
-    $A(t) - D_s(t) > m$. How can this occur? 
+    at some time~$t$ it happens that $\tilde A(t) - D(t) < m$ even though
+    $A(t) - D(t) > m$. How can this occur? 
 \begin{solution}
  In this case, there are servers idling while there are still
     customers in queue. If such events occur, we say that the server


### PR DESCRIPTION
In question 1.5.6 it is stated that we do not need a separate notation for the number of jobs that leave the server. However, in question 1.5.8, this notation is still used.