### PR TITLE
Update expdistribution.tex

### DIFF
--- a/tex_files/expdistribution.tex
+++ b/tex_files/expdistribution.tex
@@ -443,7 +443,7 @@ We next provide further relations between the Poisson distribution and the expon
  \begin{equation*}
 \E{A_i} = \frac i\lambda,
  \end{equation*}
- that is, the expected time to see $i$ jobs is $i/\lambda$.
+ that is, the expected time to have seen $i$ jobs in total is $i/\lambda$.
  \begin{hint} What is $\E{X+Y}$ for some general random variables (each with finite mean)?
  \end{hint}
   \begin{solution}


### PR DESCRIPTION
Maybe a bit of a stupid adjustment, but shouldn't this be 'have seen'? Since jobs can 'depart', the expected time to see i jobs is not the same as the expected time to have seen i jobs.  And even if jobs can't depart yet, since the text hasn't spoken of it so far, this sentencing is definitely not worse than the sentencing that was used previously. It's at least greater than or equal to. That is, if I understand the question correctly.