### PR TITLE
Update empericalperfmeasures.tex

### DIFF
--- a/tex_files/empericalperfmeasures.tex
+++ b/tex_files/empericalperfmeasures.tex
@@ -53,8 +53,8 @@ of the $k$th job.  The \recall{distribution of $\{L(t)\}$ as seen by
 \begin{exercise}
  Assume that $X_k = 10$ minutes and $S_k = 11$ minutes for all
     $k$, i.e., $X_k$ and $S_k$ are deterministic and constant. What
-    are $\lambda$ and $\mu$?  Compute $A_k$, $W_k$, $D_k$ and
-    $L(A_k-)$. How do these numbers behave as a function of $k$?
+    are $\lambda$ and $\mu$?  Compute $A_k$, $W_k$ and $D_k$. 
+    How do these numbers behave as a function of $k$?
   \begin{solution}
  $\lambda=6$ per hour, and $\mu=60/11$ per hour. Note that
       $\mu < \lambda$. $A_0 = 0$, $A_1=10$, $A_2=20$, etc., hence
@@ -65,7 +65,7 @@ of the $k$th job.  The \recall{distribution of $\{L(t)\}$ as seen by
       $D_k = 10k + k+10 = 11k+10$. Note that $W_k$ increases linearly
       as a function of $k$.  You can infer that, for the queue length
       to remain bounded, it is necessary that the service rate
-      $\mu > \lambda$.
+      $\mu > \lambda$. 
   \end{solution}
 \end{exercise}
 


### PR DESCRIPTION
L(A_k-) is not given in the solution. Either L(A_k-) should be removed from the question, or the solutions should contain the values of L(A_k-).