### PR TITLE
Update levelcrossing.tex

### DIFF
--- a/tex_files/levelcrossing.tex
+++ b/tex_files/levelcrossing.tex
@@ -116,7 +116,7 @@ straightaway.
 
 Define\footnote{It is common to write
   $f(x+) = \lim_{h\downarrow0} f(x+h)$ for the right limit of a
-  function $f$ at $x$ and $f(x-) = \lim_{h\downarrow0} f(x-h)$ for the
+  function $f$ at $x$ and $f(x-) = \lim_{h\uparrow0} f(x-h)$ for the
   left limit. When $f(x-)=f(x+)$, $f$ is continuous at $x$. Since in
   queueing systems we are concerned with processes with jumps, we need
   to be quite particular about left and right limits at jump epochs.}


### PR DESCRIPTION
the left limit is given by h towards 0 from below, not above, since as stated the right limit is given by h towards 0 from above. Changed the arrow for the left limit