### PR TITLE
Update mxm1_pk.tex

### DIFF
--- a/tex_files/mxm1_pk.tex
+++ b/tex_files/mxm1_pk.tex
@@ -494,7 +494,7 @@ Only if $B_k \geq i$ there can be an $i$th item of the batch, and the time this 
 \end{exercise}
 
 
-\begin{exercise}\label{ex:14}
+\begin{exercise}
 Use the previous exercise to show that 
 \begin{equation*}
   Y_S(i, D_n) = \sum_{k=1}^n \1{B_k\geq i} S_{k,i}.
@@ -559,7 +559,7 @@ Finally, if $H$ and $A$ would be independent (which they are not), then it is ea
 \end{exercise}
 
 
-\begin{exercise}
+\begin{exercise}\label{ex:14}
 By taking the time average, show that
 \begin{equation*}
 \P{Y_S=i} =\lim_n  \frac{Y_S(i, D_n)}{D_n} = \rho \frac{G(i-1)}{\E B}.


### PR DESCRIPTION
Reference to the wrong exercise. Placed label at the correct exercise. 
The old exercise (where I removed the label) was not referenced to anywhere else in the book, so I didn't give it a new label.