### PR TITLE
Possible error in question 1.12.14

### DIFF
--- a/tex_files/pasta.tex
+++ b/tex_files/pasta.tex
@@ -486,7 +486,7 @@ From PASTA $\pi(n) = p(n)$, hence the fraction of jobs that see a busy server mu
 \end{exercise}
 
 \begin{exercise}
-Show  that when the server is busy at $D_{n-1}$, the density of the inter-departure time is $f_D(t) = \mu e^{-\mu t}$.
+Show  that when the server is idle at $D_{n-1}$, the density of the inter-departure time is $f_D(t) = \mu e^{-\mu t}$.
     \begin{solution}
 The server can start right away with a new job. The departure times are exponentially distributed. 
     \end{solution}


### PR DESCRIPTION
If the server is busy at Dn-1 then service can NOT start right away for the job n, right? Because Dn-1 is the departure moment of job n-1 so if the server is busy at that point (in a M/M/1 system) it can NOT start servnig job n.