### PR TITLE
Update mnmn1.tex

### DIFF
--- a/tex_files/mnmn1.tex
+++ b/tex_files/mnmn1.tex
@@ -88,7 +88,7 @@ For the $M/M/c$ queue we can take
 \lambda(n) &= \lambda, \\
     \mu(n) &= 
   \begin{cases}
-    n\mu, &\text{ if } n \leq c, \\
+    n\mu, &\text{ if } n < c, \\
     c\mu, &\text{ if } n \geq c.
   \end{cases}
   \end{align*}


### PR DESCRIPTION
Not sure  but shouldn't "n \leq c" be "n < c" since  it otherwise isn't in line with the convention used elsewhere in the doc to not have overlapping in equalities?