### PR TITLE
Update levelcrossing.tex

### DIFF
--- a/tex_files/levelcrossing.tex
+++ b/tex_files/levelcrossing.tex
@@ -365,7 +365,7 @@ $D(n,t)$ and $\mu(n+1)$ for $n\geq 0$.
 \begin{solution}
   $D(0,t) = \sum_{k=1}^\infty\1{D_k\leq t, L(D_k)=0}$. From the graph of $\{L(s)\}$ we see that all jobs leave an empty system behind. Thus, $D(0,t) \approx t/2$, and $D(n,t)=0$ for $n\geq 1$. With this, $D(0,t)/Y(1,t) \sim (t/2)/(t/2) = 1$, and so,
   \begin{equation*}
-    \mu(1) = \lim_t \frac{D(0,t)}{Y(1, t)} = 1,
+    \mu(1) = \lim_{t\to\infty} \frac{D(0,t)}{Y(1, t)} = 1,
   \end{equation*}
 and $\mu(n) = 0$ for $n\geq2$. 
 \end{solution}


### PR DESCRIPTION
consistent notation for a limit where t>infinity instead of only t