### PR TITLE
Fix phrasing in reference to D(t)

### DIFF
--- a/tex_files/levelcrossing.tex
+++ b/tex_files/levelcrossing.tex
@@ -22,7 +22,7 @@ at time $t$ is equal to $A(t) - D(t)$. To illustrate:
 \end{tikzpicture}
 \end{figure}
 
-\noindent What goes in the box (i.e., $A(t)$) and has not yet left
+\noindent What goes in the box (i.e., $A(t)$) minus that which has already left
   (i.e., $D(t)$) must still be in the box, hence $L(t)=A(t)-D(t)$). 
 
 

--- a/tex_files/levelcrossing.tex
+++ b/tex_files/levelcrossing.tex
@@ -22,7 +22,7 @@ at time $t$ is equal to $A(t) - D(t)$. To illustrate:
 \end{tikzpicture}
 \end{figure}
 
-\noindent What goes in the box (i.e., $A(t)$) minus that which has already left
+\noindent What goes in the box (i.e., $A(t)$) minus what has already gone out
   (i.e., $D(t)$) must still be in the box, hence $L(t)=A(t)-D(t)$). 
 
 


### PR DESCRIPTION
As is, the text seems to suggest D(t) captures that part 'which has not yet left', which is not quite true: D(t) captures those jobs that have left by time t, such that A(t) - D(t) is 'that part which has not yet left'.