### PR TITLE
Update mg1distributionqueuelength.tex

### DIFF
--- a/tex_files/mg1distributionqueuelength.tex
+++ b/tex_files/mg1distributionqueuelength.tex
@@ -425,7 +425,7 @@ Again we define proper counting functions,  divide by $t$, and take suitable lim
 \end{equation}
 
 \begin{exercise}
-Provide the details behind the derivation of Eq.~\ref{eq:555}.
+Provide the details behind the derivation of Eq.~\eqref{eq:555}.
 \begin{hint}
 Define for $m=1,\ldots, n$
 \begin{equation*}
@@ -481,7 +481,7 @@ state probabilities, and follow the approach sketched below Exercise~\ref{ex:13}
  Define shorthands
     such as $\alpha=\lambda/(\lambda+\mu)$, so that
     $1-\alpha = \mu/(\lambda+\mu)$, and
-    $\alpha/(1-\alpha) = \lambda /\mu = \rho$.  Then, with Eq.~\ref{eq:41}, $f(n) = \alpha^n(1-\alpha)$ and $G(n) = \alpha^{n+1}$.  (These results do not 'come for
+    $\alpha/(1-\alpha) = \lambda /\mu = \rho$.  Then, with Eq.~\eqref{eq:41}, $f(n) = \alpha^n(1-\alpha)$ and $G(n) = \alpha^{n+1}$.  (These results do not 'come for
     free'. Of course, it's just algebra, but please try to derive this
     yourself. It's good to hone your computational skills.)
   \end{hint}


### PR DESCRIPTION
chaged \ref to \eqref since we refer to equations