### PR TITLE
Update batcharrivals.tex

### DIFF
--- a/tex_files/batcharrivals.tex
+++ b/tex_files/batcharrivals.tex
@@ -9,7 +9,7 @@
 \Opensolutionfile{hint}
 \Opensolutionfile{ans}
 
-In Sections~\ref{sec:mxm1-queue:-expected} and~\ref{sec:mg1} we established the Pollackzek-Khintchine formula for the waiting times of the $M^X/M/1$ queue and $M/G/1$ queue, respectively.
+In Sections~\ref{sec:mxm1-queue:-expected} and~\ref{sec:mg1} we established the Pollackzek-Khinchine formula for the waiting times of the $M^X/M/1$ queue and $M/G/1$ queue, respectively.
 To compute more difficult performance measures, for instance the loss probability $\P{L>n}$, we need expressions for the stationary distribution  $\pi(n)=\P{L=n}$ of the number of jobs in the system. Here we present a numerical, recursive, scheme to compute these probabilities.
 
 To find $\pi(n)$, $n=0, 1, \ldots$, we turn again to level-crossing arguments.


### PR DESCRIPTION
changed "Pollackzek-Khintchine" into "Pollackzek-Khinchine"  since we use Pollackzek-Khinchine elsewhere in the book.