### PR TITLE
Update mg1distributionqueuelength.tex

### DIFF
--- a/tex_files/mg1distributionqueuelength.tex
+++ b/tex_files/mg1distributionqueuelength.tex
@@ -515,9 +515,9 @@ that we are left with checking that
 &= \alpha^{n+1} - \alpha^{n+1}(1-(\rho/\alpha)^n), \quad\text{as } \rho/\alpha = 1+\rho,\\
 &= \alpha^{n+1}(\rho/\alpha)^n = \alpha \rho^n.\\
 \end{align*}
-Since $\rho=\alpha/(1-\alpha)$ we see that the left and right-hand sides are the same. 
+Since $\rho=\alpha/(1-\alpha)$ we see that the left- and right-hand sides are the same. 
 
-Thus we get that $\pi(n) = \delta(n) = (1-\rho) \pi(0)$; a result we
+Thus we get that, by using PASTA, $p(n) = \pi(n) = \rho^n \pi(0) = \rho^n (1-\rho)$; a result we
 obtained earlier for the $M/M/1$ queue.
 \end{solution}
 \end{exercise}


### PR DESCRIPTION
added "-" to left since it is left-hand side.
Furthermore in line 506 we stated that \pi(n) = \rho^n \pi(0), so changed "\pi(n) = (1-\rho) \pi(0)" to "\pi(n) = \rho^n \pi(0)" and since \pi(0) = (1-\rho) the result holds.
Furthermore in the exercise was asked to obtain p(n) = (1-\rho) \rho^n by using the equation 1.18.6. Therefore I changed \delta(n) into p(n) and added that we used the PASTA property for \pi(n) = p(n).