### PR TITLE
Update open_single_class.tex

### DIFF
--- a/tex_files/open_single_class.tex
+++ b/tex_files/open_single_class.tex
@@ -103,7 +103,7 @@ A =
       0 & 0 & 0 \\ 
     \end{pmatrix}.
   \end{equation*}
-Clearly, $A$ has an eigenvalue $0$. Now take $v=(x,y,z)'$, so that
+Clearly, $A$ has an eigenvalue $0$. Now take $v=(x,y,z)$, so that
     \begin{equation*}
 A v = A
  \begin{pmatrix}


### PR DESCRIPTION
deleted the transpose sign, since I believe that the standing vector is just (x,y,z) and not (x,y,z)'. If it is not the right way to denote the standing vector this way, then the vectors given in line 122, namely w=(x,y,0) and v=(x,y,z) need a transpose sign.