### PR TITLE
Update tandem.tex

### DIFF
--- a/tex_files/tandem.tex
+++ b/tex_files/tandem.tex
@@ -166,7 +166,7 @@ than at one.
   \end{solution}
 \end{exercise}
 
-For a tandem network of $G/G/1$ queues, observe that the SCV of the departure process $C_{d,i}^2$ of the $i$th station $i$ is the SCV of the arrival process $C_{a,i+1}^2$ at station $i+1$.  Thus, if we have $C_{d,i}^2$ we can compute the average waiting time at station~$i+1$ by means of the $G/G/1$ waiting time approximation. 
+For a tandem network of $G/G/1$ queues, observe that the SCV of the departure process $C_{d,i}^2$ of the $i$th station is the SCV of the arrival process $C_{a,i+1}^2$ at station $i+1$.  Thus, if we have $C_{d,i}^2$ we can compute the average waiting time at station~$i+1$ by means of the $G/G/1$ waiting time approximation. 
 
 To obtain an estimate for $C_{d,i}^2$ we reason as follows.
 Suppose that the load $\rho_i$ at station~$i$ is very high.


### PR DESCRIPTION
removed ''i'', since we already stated that it is the SCV of the departure process of the ith station.