### PR TITLE
Update tandem.tex

### DIFF
--- a/tex_files/tandem.tex
+++ b/tex_files/tandem.tex
@@ -197,7 +197,7 @@ What is $C_d^2$ for the $M/M/1$ queue according to~\eqref{eq:40}?
 \begin{exercise}
   Use~\eqref{eq:40} to show for the $G/D/1$ that $C_d^2 < C_a^2$. 
   \begin{solution}
-As $C_s^2 = 0$ for the $G/D/1$ queue, $C_3^2 = (1-\rho^2) C_a^2 < C_a^2$, as $\rho<1$. 
+As $C_s^2 = 0$ for the $G/D/1$ queue, $C_d^2 = (1-\rho^2) C_a^2 < C_a^2$, as $\rho<1$. 
   \end{solution}
 \end{exercise}
 


### PR DESCRIPTION
changed the "3" into a "d" since it is the SCV of the departure process