### PR TITLE
Update ratestability.tex

### DIFF
--- a/tex_files/ratestability.tex
+++ b/tex_files/ratestability.tex
@@ -8,7 +8,7 @@
 
 In the analysis of any queueing process the first step should be to check the relations between the arrival, service and departure rates.
 The concept of rate is crucial because it captures our intuition that when, on the long run, jobs arrive faster than they can leave, the system must `explode'.
-Thus, the first performance measures we need to estimate when analyzing a queueing system are the arrival and departure rate, and then we need to check that the arrival rate is smaller than the departure rate.
+Thus, the first performance measures we need to estimate when analyzing a queueing system are the arrival and departure rate, and then we need to check that the arrival rate is smaller than the service rate.
 
 We first formalize the \emph{arrival rate} and \emph{departure rate} in terms of the \emph{counting processes} $\{A(t)\}$ and $\{D(t)\}$.
 The \recall{arrival rate} is the long-run average number of jobs that arrive per unit time, i.e.,


### PR DESCRIPTION
Changed departure rate into service rate, since if arrival rate is smaller than the departure rate. the system will just ''create'' jobs which is impossible. It makes more sense to check that arrival rate is smaller than service rate, since otherwise the system will explode.