### PR TITLE
Update levelcrossing.tex

### DIFF
--- a/tex_files/levelcrossing.tex
+++ b/tex_files/levelcrossing.tex
@@ -374,7 +374,7 @@ and $\mu(n) = 0$ for $n\geq2$.
 Observe that customers arrive and depart as single units. Thus, if
 $\{T_k\}$ is the ordered set of arrival and departure times of the
 customers, then $L(T_k) = L(T_k-) \pm 1$. But then we must also have
-that $|A(n,t) - D(n,t)| \leq 1$ (Think about this.). From this
+that $|A(n,t) - D(n,t)| \leq 1$ (think about this). From this
 observation it follows immediately that
 \begin{equation}\label{eq:15}
   \lim_{t\to\infty} \frac{A(n,t)}t = \lim_{t\to\infty} \frac{D(n,t)}t.


### PR DESCRIPTION
changed the capital letter into a normal letter and deleted a dot, since it was in the sentence. Another possibility is given in another pull request. But I think this one is better.