### PR TITLE
Update poissondistribution.tex

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -263,7 +263,7 @@ Write $N(s, t]$ for the number of arrivals in the interval $(s,t]$. First we mak
 Thus, 
     \begin{align*}
   \P{N(t+h) = n | N(t) = n} 
-&=  \frac{\P{N(t+h) = n, N(t) = n}}{P{N(t)=n}} \\
+&=  \frac{\P{N(t+h) = n, N(t) = n}}{\P{N(t)=n}} \\
 &=  \frac{\P{N(t, t+h] = 0,  N(t) = n}}{\P{N(t)=n}} \\
 &=  \frac{\P{N(t, t+h] = 0} \P{N(t) = n}}{\P{N(t)=n}}, \quad \text{(independence)}\\
 %& \quad\text{(by independence of } N(t, t+h] \text{ and } N(t))\\


### PR DESCRIPTION
There was a \ missing resulting in the letter P instead of a probability.