### PR TITLE
Update constructiondiscretetime.tex

### DIFF
--- a/tex_files/constructiondiscretetime.tex
+++ b/tex_files/constructiondiscretetime.tex
@@ -66,7 +66,7 @@ in the latter case, they \emph{cannot} be served in period~$k$.
 
 
 Let  $L_{k-1}$ be the queue length at the end of period $k-1$, it
-must also be the number of customers at the start of period $k$. Assuming
+must also be the number -of customers at- the start of period $k$. Assuming
 that jobs arriving in period $k$ cannot be served in period~$k$,
 the number of customers that depart in period $k$
 is


### PR DESCRIPTION
Do not approve this pull request.

When reading the queueing_book_mobile.pdf, the text which I put in between hyphens falls off the page. The text reads 'it must also be the number the start of period k.' I don't know if this is a general problem or just a problem for me, please take a look.