### PR TITLE
Update poissondistribution.tex

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -7,7 +7,7 @@
 \Opensolutionfile{ans}
 }
 
-In this section we provide motivation for the use of the Poisson process as an arrival process of customers or jobs at a shop, service station, or machine to receive service.  In the exercises we derive numerous  properties of  this exceedingly important distribution; in the rest of the book we will use these results time and again.
+In this section, we provide motivation for the use of the Poisson process as an arrival process of customers or jobs at a shop, service station, or machine to receive service.  In the exercises, we derive numerous  properties of  this exceedingly important distribution; in the rest of the book, we will use these results time and again.
 
 Consider a stream of customers that enter a shop over time.
 Let us write $N(t)$ for the number of customers that enter during the time interval $[0,t]$ and $N(s, t] = N(t)-N(s)$ for the number that arrive in the time period $(s, t]$.
@@ -31,7 +31,7 @@ Independence means, roughly speaking, that knowing that $N(s,t]= n$, does not he
 
 
 
-To find the distribution of $N(t)$ for some given $t$, let us split the interval $[0,t]$ into $n$ sub-intervals, all of equal length, and ask: `What is the probability that a customer arrives in some given sub-interval?'
+To find the distribution of $N(t)$ for some given $t$, let us split the interval $[0,t]$ into $n$ sub-intervals, all of the equal length, and ask: `What is the probability that a customer arrives in some given sub-interval?'
 By our first assumption, the arrival rate is constant over time.
 Therefore, the probability~$p$ of an arrival in each interval should be constant.
 Moreover, if the time intervals are very small, we can safely neglect the probability that two or more customers arrive in one interval.
@@ -69,7 +69,7 @@ What is the difference between $N_n(t)$ and $N(t)$?
   $N_n(t)$ is a binomially distributed random variable with parameters $n$ and $p$.
   The maximum value of $N_n(t)$ is $n$.
   The random variable $N(t)$ models the number of arrivals that can occur during $[0,t]$.
-  As such it is not necessarily bounded by $n$.
+  As such, it is not necessarily bounded by $n$.
   Thus, $N_n(t)$ and $N(t)$ cannot represent the same random variable.
 \end{solution}
 \end{extra}
@@ -81,7 +81,7 @@ What is the difference between $N_n(t)$ and $N(t)$?
  \end{equation*}
  if $n\to\infty$, $p\to0$ such that $n p=\lambda t$.
 \begin{hint}
-    First find $p$, $n$, $\lambda$ and $t$ such that the rate at which an event occurs in both processes are the same.
+    First, find $p$, $n$, $\lambda$ and $t$ such that the rate at which an event occurs in both processes is the same.
     Then consider the binomial distribution and use the standard limit $(1-x/n)^n \to e^{-x}$ as $n\to \infty$.
 \end{hint}
 \begin{solution}
@@ -119,7 +119,7 @@ Observe that the process $N_\lambda$ is a much more complicated object than a Po
 The process is an uncountable set of random variables indexed by $t\in \R^+$, not just \emph{one} random variable.
 
 
-In the remainder of this section we derive a number of  properties of the Poisson process that we will use time and again.
+In the remainder of this section, we derive a number of  properties of the Poisson process that we will use time and again.
 
 
 \begin{exercise} \clabel{ex:35}
@@ -353,9 +353,9 @@ The relative variability of the Poisson process goes down as $t\to\infty$.
 
 
 
-\recall{Merging} Poisson processes occurs often in practice.
+\recall{Merging} Poisson processes often occurs in practice.
 We have two Poisson processes, for instance, the arrival processes $N_\lambda$ of men and $N_\mu$ of women at a shop.
-In the figure below, each cross represents an arrival; in the upper line it corresponds to a man, in the middle line to a woman, and in the lower line to an arrival of a general customer at the shop.
+In the figure below, each cross represents an arrival; in the upper line, it corresponds to a man, in the middle line to a woman, and in the lower line to an arrival of a general customer at the shop.
 Thus, the shop `sees' the superposition of these two arrival processes.
 In fact, this merged process $N_{\lambda+\mu}$ is also a Poisson process with rate $\lambda+\mu$.
 
@@ -464,7 +464,7 @@ Use the standard formula for conditional probability and that  $N_\lambda(t) + N
 Besides merging Poisson streams, we can also consider the concept of \emph{splitting}, or \emph{thinning}, a stream into sub-streams, as follows.
 % When a customer arrives, throw a coin that lands heads with probability $p$ and tails with $q=1-p$.
 % When the coin lands heads, the customer is of type 1 (e.g., a woman), otherwise of type 2 (e.g., a child).
-Model the stream of people passing by a shop as a Poisson process $N_\lambda$. In the figure below these arrivals are marked as crosses at the upper line. 
+Model the stream of people passing by a shop as a Poisson process $N_\lambda$. In the figure below, these arrivals are marked as crosses at the upper line. 
 With probability $p$ a person decides, independent of anything else, to enter the shop; the crosses at the lower line are the customers that enter the shop.
 In the figure, the Bernoulli random variable $B_1=1$ so that the first passerby enters the shop; the second passerby does not enter as $B_2=0$, and so on.
 
@@ -574,7 +574,7 @@ With ~\cref{eq:77},
 \end{solution}
 \end{exercise}    
 
-The concepts of merging and thinning are useful to analyze queueing networks.
+The concepts of merging and thinning are useful in analyzing queueing networks.
 Suppose the departure stream of a machine splits into two sub-streams, e.g., a fraction $p$ of the jobs moves on to another machine and the rest ($1-p$) of the jobs leaves the system.
 Then we can model the arrival stream at the second machine as a thinned stream (with probability $p$) of the departures of the first machine.
 Merging occurs where the output streams of various stations arrive at another station.


### PR DESCRIPTION
I think from equation 1.2.2 we jumps to the assumption np = \lambda t is a bit out of a sudden. We can immediately see np is related to counting the people in n intervals (up to infinity) while p ->0 if the interval is small enough. However, I think how \lambda t is related to np needs further explanation. I think this assumption is related to Homogeneous Poisson point process  which can also be defined as a counting process (a type of stochastic process). Shall I add some explanations there?