### PR TITLE
Update poissondistribution.tex

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -408,7 +408,7 @@ Take expectations left and right, use~\cref{eq:74}, and  independence of $N_\lam
 \end{exercise}
 
 \begin{extra}
-  If the Poisson arrival processes $N_\lambda$ and $N_\mu$ are independent, use moment-generating functions to show that $N_\lambda + N_\mu$ is a Poisson process with rate $(\lambda + \mu)t$.
+  If the Poisson arrival processes $N_\lambda$ and $N_\mu$ are independent, use moment-generating functions to show that $N_\lambda + N_\mu$ is a Poisson process with rate $\lambda + \mu$.
 \begin{hint}
   Use~\cref{eq:73} and~\cref{eq:75}.
 \end{hint}


### PR DESCRIPTION
If line 388 is not necessary to be changed, then maybe this line should also be '\lambda+\mu' to be consistent.  Since they are asking the same question. I thought maybe it's better to modify line 388 because in previous context P(\lambda t) is used to describe Poisson process? I'm not sure which way is preferred.