### PR TITLE
random walk missing comma

### DIFF
--- a/tex_files/random_walk.tex
+++ b/tex_files/random_walk.tex
@@ -153,7 +153,7 @@ and we call $Z=\{Z_k\}$ the \emph{free} (discrete-time) $M/M/1$ queue as, contra
 The solution of the above exercise shows that there is no simple function by which we can compute the transient distribution of this simple random walk $Z$.
 Since a queueing process is typically a more complicated object (as we need to obtain $L$ from $Z$ via~\cref{eq:reich1}), our hopes of finding anything simple for the transient analysis of the $M/M/1$ queue should not be too high.
 But the $M/M/1$ queue is about the simplest queueing system; other queueing systems are (much) more complicated.
-We therefore give up the analysis of the transient behavior of queueing systems and henceforth contend ourselves with the analysis of queueing systems in the limit as $t\to\infty$.
+We, therefore, give up the analysis of the transient behavior of queueing systems and henceforth contend ourselves with the analysis of queueing systems in the limit as $t\to\infty$.
 The limiting random variable $L$ is known as the \recall{steady-state limit} of the sequence of random variables $\{L_k\}$, and the distribution of~$L$ is known as the \recall{limiting distribution} or \emph{stationary distribution} of $\{L_k\}$.
 Taking these limits warrants two questions: what type of limit is actually meant here, and what is the rate of convergence to this limiting situation?
 Here we sidestep all such fundamental issues, as the details require measure theory and more advanced probability theory than we can deal with here.


### PR DESCRIPTION
There are comma's missing before and after therefore