### PR TITLE
solution-1.2.18

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -591,7 +591,7 @@ M_Y(s) = \E{e^{s\sum_{i=1}^n Z_i}} = \left(\E{e^{s Z}}\right)^n = \left(1 + p (e
 \end{equation*}
 Recall that $p= \lambda t/ n$. Then, with~\cref{eq:65},
 \begin{equation*}
-\lim_{n\to\infty} \left(1 + \frac{\lambda t}{n} (e^s - 1)\right)^n = \exp{\lambda t (e^s-1)}. 
+\lim_{n\to\infty} \left(1 + \frac{\lambda t}{n} (e^s - 1)\right)^n = \exp{(\lambda t (e^s-1))}. 
 \end{equation*}
 Thus, the limit becomes equal to the moment-generating function of the Poisson distribution. 
 \end{solution}


### PR DESCRIPTION
There should be brackets to show as exp() instead of exp