### PR TITLE
deterministic_networks adding 'the'

### DIFF
--- a/tex_files/deterministic_networks.tex
+++ b/tex_files/deterministic_networks.tex
@@ -461,7 +461,7 @@ W_0 = r_b T_0 = \frac 12 \frac{23}5 = \frac{23}{10}.
 % include anyway in a CONWIP loop, and why?
 % \end{exercise}
 % \begin{solution}
-% Now stations 1 and 3 are bottleneck. Thus, both stations need to be
+% Now stations 1 and 3 are the bottleneck. Thus, both stations need to be
 % part of the conwip loop. For that matter, it is just as easy to also
 % include station 2, and just include all work on the floor in the WIP
 % measurements.

--- a/tex_files/deterministic_networks.tex
+++ b/tex_files/deterministic_networks.tex
@@ -445,7 +445,7 @@ which agrees with our earlier result.
  i.e., 1/5 of the jobs have the routing $[1,2,3]$, but 4/5 have
  routing $[1,3]$. What are $W_0$, $r_b$ and $T_0$?
 \begin{solution}
- Now stations 1 and 3 are bottlenecks with $r_b = 1/2$. For $T_0$ we have
+ Now stations 1 and 3 are the bottlenecks with $r_b = 1/2$. For $T_0$ we have
  \begin{equation*}
  T_0 = \frac15 7 + \frac45 4= \frac{23}5.
  \end{equation*}

--- a/tex_files/deterministic_networks.tex
+++ b/tex_files/deterministic_networks.tex
@@ -461,7 +461,7 @@ W_0 = r_b T_0 = \frac 12 \frac{23}5 = \frac{23}{10}.
 % include anyway in a CONWIP loop, and why?
 % \end{exercise}
 % \begin{solution}
-% Now stations 1 and 3 are the bottleneck. Thus, both stations need to be
+% Now stations 1 and 3 are the bottlenecks. Thus, both stations need to be
 % part of the conwip loop. For that matter, it is just as easy to also
 % include station 2, and just include all work on the floor in the WIP
 % measurements.


### PR DESCRIPTION
'the' should be added in front of bottleneck. Maybe depending on context bottleneck could be changed to bottlenecks