### PR TITLE
random_walk a_k -> a_j

### DIFF
--- a/tex_files/random_walk.tex
+++ b/tex_files/random_walk.tex
@@ -105,7 +105,7 @@ Suppose that $a_k\sim P(\lambda)$ and $c_k \sim P(\mu)$.
 
 \begin{exercise}\clabel{ex:89}
   Show that if $\{a_k\}$ forms an i.i.d.
-sequence of random variables all Poisson distributed $P(\lambda)$ then, $\sum_{j=1}^k a_k = P(\lambda k)$. 
+sequence of random variables all Poisson distributed $P(\lambda)$ then, $\sum_{j=1}^k a_j = P(\lambda k)$. 
 \begin{hint}
 Use~\cref{ex:1}.
 \end{hint}


### PR DESCRIPTION
In this case the subscript should be j in stead of k since it has to be under influence of the summation sign.