### PR TITLE
Update constructiondiscretetime.tex

### DIFF
--- a/tex_files/constructiondiscretetime.tex
+++ b/tex_files/constructiondiscretetime.tex
@@ -644,7 +644,7 @@ Aumann and Maschler applied this principle to clarify certain division rules dis
  \begin{equation*}
 d_{A,k} = \min\{L_{A,k-1}, c_k-c_{B,k}\}.
 \end{equation*}
-And then we can give any left over capacity to queue B, if needed. 
+And then we can give any leftover capacity to queue B, if needed. 
 \begin{align*}
 d_{B, k} &= \min\{L_{B, k-1}, c_k-d_{A,k}\}.
 \end{align*}


### PR DESCRIPTION
Before a noun, 'leftover' should be used instead of 'left over'.