### PR TITLE
Update poissondistribution.tex

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -10,7 +10,7 @@
 In this section, we provide motivation for the use of the Poisson process as an arrival process of customers or jobs at a shop, service station, or machine to receive service. In the exercises we derive numerous properties of this exceedingly important distribution; in the rest of the book we will use these results time and again.
 
 Consider a stream of customers that enter a shop over time.
-Let us write $N(t)$ for the number of customers that enter during the time interval $[0,t]$ and $N(s, t] = N(t)-N(s)$ for the number that arrive in the time period $(s, t]$.
+Let us write $N(t)$ for the number of customers that enters during the time interval $[0,t]$ and $N(s, t] = N(t)-N(s)$ for the number that arrive in the time period $(s, t]$.
 Clearly, as we do not know in advance how many customers will enter, we model the set $\{N(t), t\geq 0\}$ as a family of random variables.
 
 Our first assumption is that the rate at which customers enter stays constant over time. Then it is reasonable to assume that


### PR DESCRIPTION
I have proposed this file change before and I still believe it is right according to the following:
In this case the collective noun number functions as the subject of the sentence, and thus requiring a singular verb. The fact that number in these cases is preceded by _the_ requires the singular verb.
From https://www.dictionary.com/e/collective-nouns/