### PR TITLE
Update levelcrossing.tex

### DIFF
--- a/tex_files/levelcrossing.tex
+++ b/tex_files/levelcrossing.tex
@@ -577,7 +577,7 @@ for queueing networks.
 
 \end{tikzpicture}
 \caption{ For the balance equations we count how often a box around a
- state is crossed from inside and outside. On the long run the
+ state is crossed from inside and outside. On the long run, the
  entering and leaving rates should be equal. For the example here,
  the rate out is $p(2)\lambda(2) + p(2) \mu(2)$ while the rate in is
  $p(1)\lambda(1)+p(3)\mu(3)$.}


### PR DESCRIPTION
Added comma after 'On the long run' (line 580), which I already proposed to change to 'In the long run' in a previous pull request.