### PR TITLE
Update pasta.tex

### DIFF
--- a/tex_files/pasta.tex
+++ b/tex_files/pasta.tex
@@ -58,7 +58,7 @@ Thus, for the $M/M/1$ queue in particular,
 \end{equation*}
 
 \begin{exercise}\clabel{ex:8} 
-Show for the case of~\cref{ex:112} that $\pi(0)=1$ and $\pi(n)=0$, for $n>0$.
+Show for the case of~\cref{ex:111} that $\pi(0)=1$ and $\pi(n)=0$, for $n>0$.
 \begin{solution}
   All arrivals see an empty system.
   Hence $A(0,t)/A(t) \approx (t/2)/(t/2) = 1$, and $A(n,t)=0$ for $n>0$.


### PR DESCRIPTION
ex:112(2.4.2) is continuation of ex:111(2.4.1) which did not explain the arrival process on queueing book, maybe it's better to refer to the ex:111(2.4.1) here for better indication.