### PR TITLE
Update tandem.tex

### DIFF
--- a/tex_files/tandem.tex
+++ b/tex_files/tandem.tex
@@ -21,7 +21,7 @@ However, when the machines act like $M/M/c$ queues, it is possible to fully anal
 
 With simulation it has been tested that the SCV of the inter-departure times of a $G/G/c$ queue can be reasonable well approximated by
 \begin{equation}\label{eq:57}
- C_{d}^2 = 1 + (1-\rho^2)(C_{a}^2-1) + \frac{\rho^2}{\sqrt{c}}(C_{s}^2-1).
+ C_{d}^2 \approx 1 + (1-\rho^2)(C_{a}^2-1) + \frac{\rho^2}{\sqrt{c}}(C_{s}^2-1).
 \end{equation}
 
 


### PR DESCRIPTION
consistency of notation. the approximation sign is also used when discussing the G/G/1 queue.