### PR TITLE
Jiacheng andy li patch 2

### DIFF
--- a/tex_files/gershgorin.tex
+++ b/tex_files/gershgorin.tex
@@ -17,7 +17,7 @@ Then the probability that a job starting at $k$, moving to $i$ and then leaving 
 As $P_{ki}>0$ and $P_{i0}>0$, the probability that a job leaves the network from node $k$ in two steps is positive.
 As a matter of fact, $P^2_{k0} = \sum_{j=0}^M P_{kj}P_{j0} \geq P_{ki}P_{i0} > 0$.
 More generally, we assume that the (finite) matrix $P$ is transient, which means that it is possible to leave the network from any station in at most $M$ steps.
-In other words, for any station $j$ there is a sequence of intermediate stations $j_1, j_2, \ldots , j_{M-1}$ such that $P^{M}_{jk} \geq P_{j j_1}P_{j_1 j_2}\cdots P_{j_{M-1}k} > 0$.
+In other words, for any station $j$ there is a sequence of intermediate stations $j_1, j_2, \ldots , j_{M-1}$ such that $P^{M}_{j0} \geq P_{j j_1}P_{j_1 j_2}\cdots P_{j_{M-1}0} > 0$.
 
 \begin{extra}
   What type of networks lead to the longest chains before jobs can leave the network? What routing matrix~$P$ corresponds to such a network? Show that $P^M = 0$ for such networks.

--- a/tex_files/n_policies_mg1.tex
+++ b/tex_files/n_policies_mg1.tex
@@ -78,7 +78,7 @@ Integrating  both sides with respect to $s$ gives $U(s) - U(0) = \lambda h s^2/2
 \end{solution}
 \end{exercise}
 
-Since $U(s)$ is the expected total cost given that the service time is $s$, it follows from~\cref{ex:mg1-3} that $\E{U(S)} = \lambda h \E{S^2}$ is the expected queueing cost of the new jobs that arrive during the service.
+Since $U(s)$ is the expected total cost given that the service time is $s$, it follows from~\cref{ex:mg1-3} that $\E{U(S)} = \frac{1}2 \lambda h \E{S^2}$ is the expected queueing cost of the new jobs that arrive during the service.
 By combining the first and second component of $H(q)$, we obtain
 \begin{equation*}
   H(q) = h q \E S + \frac 12 \lambda h \E{S^2}.


### PR DESCRIPTION
Under irreducibility, it takes at most M-1 steps to go from any node to any node, and M steps to leave from any node. Given the context I think maybe you meant p^M_i_0 >0 instead of p^M_i_k>0 ?
